### PR TITLE
added no cache docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim-buster
 LABEL maintainer="ronmarti18@gmail.com"
 
-RUN pip install poetry
+RUN --no-cache-dir pip install poetry
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
 pip cache makes the images larger and is not needed, it's better to disable it.